### PR TITLE
Update Serilog dependency version in nuspec

### DIFF
--- a/src/Destructurama.Attributed/Destructurama.Attributed.nuspec
+++ b/src/Destructurama.Attributed/Destructurama.Attributed.nuspec
@@ -11,7 +11,7 @@
     <iconUrl>http://destructurama.github.io/pages/images/destructurama.png</iconUrl>
     <tags>serilog attributed</tags>
     <dependencies>
-      <dependency id="Serilog" version="1.5.7" />
+      <dependency id="Serilog" version="2.0.0" />
     </dependencies>
   </metadata>
 </package>


### PR DESCRIPTION
Hey Nick!  

Sorry.  I had forgotten to manually update the nuspec dependency version for Serilog.  In internal projects I've automated this to happen before the nuget pack based on the packages.config, so it slipped my mind.

Thanks!
--Ben