### PR TITLE
Added the ability to mask logged values instead of removing them completely

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,62 @@ log.Information("Logging in {@Command}", command);
 
 To prevent destructuring of a type or property at all, apply the `[LogAsScalar]` attribute.
 
+#### Masking a string property
+
+Apply the `LogMasked` attribute with various settings:
+
+```csharp
+public class Creditcard
+{
+  /// <summary>
+  /// 123456789 results in "*********"
+  /// </summary>
+  [LogMasked]
+  public string DefaultMasked { get; set; }
+  
+  /// <summary>
+  ///  123456789 results in "#########"
+  /// </summary>
+  [LogMasked(Mask: '#')]
+  public string CustomMasked { get; set; }
+  
+  /// <summary>
+  ///  123456789 results in "123******"
+  /// </summary>
+  [LogMasked(ShowFirst: 3)]
+  public string ShowFirstThreeThenDefaultMasked { get; set; }
+
+  /// <summary>
+  /// 123456789 results in "******789"
+  /// </summary>
+  [LogMasked(ShowLast: 3)]
+  public string ShowLastThreeThenDefaultMasked { get; set; }
+  
+  /// <summary>
+  ///  123456789 results in "123######"
+  /// </summary>
+  [LogMasked(Mask: '#', ShowFirst: 3)]
+  public string ShowFirstThreeThenCustomMask { get; set; }
+
+  /// <summary>
+  ///  123456789 results in "######789"
+  /// </summary>
+  [LogMasked(Mask: '#', ShowLast: 3)]
+  public string ShowLastThreeThenCustomMask { get; set; }
+  
+  /// <summary>
+  /// 123456789 results in "123***789"
+  /// </summary>
+  [LogMasked(ShowFirst: 3, ShowLast: 3)]
+  public string ShowFirstAndLastThreeAndDefaultMaskeInTheMiddle { get; set; }
+
+  /// <summary>
+  ///  123456789 results in "123###789"
+  /// </summary>
+  [LogMasked(Mask: '#', ShowFirst: 3, ShowLast: 3)]
+  public string ShowFirstAndLastThreeAndCustomMaskInTheMiddle { get; set; }
+}
+```
+
+
+

--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ To prevent destructuring of a type or property at all, apply the `[LogAsScalar]`
 
 Apply the `LogMasked` attribute with various settings:
 
+ - **Text**: If set the properties value will be set to this text.
+ - **ShowFirst**: Shows the first x characters in the property value 
+ - **ShowLast**: Shows the last x characters in the property value 
+ - **PreserveLength**: If set it will swap out each character with the default value. Note that this property will be ignored if Text has been set to custom value.
+
+ **Examples**
+
 ```csharp
 public class Creditcard
 {
@@ -57,35 +64,59 @@ public class Creditcard
   public string DefaultMasked { get; set; }
   
   /// <summary>
-  ///  123456789 results in "#########"
+  ///  123456789 results in "REMOVED"
   /// </summary>
-  [LogMasked(Mask: '#')]
+  [LogMasked(Text: "REMOVED")]
   public string CustomMasked { get; set; }
   
   /// <summary>
-  ///  123456789 results in "123******"
+  ///  123456789 results in "123***"
   /// </summary>
   [LogMasked(ShowFirst: 3)]
   public string ShowFirstThreeThenDefaultMasked { get; set; }
 
   /// <summary>
-  /// 123456789 results in "******789"
+  ///  123456789 results in "123******"
+  /// </summary>
+  [LogMasked(ShowFirst: 3, PreserveLength = true)]
+  public string ShowFirstThreeThenDefaultMaskedPreserveLength { get; set; }
+
+  /// <summary>
+  /// 123456789 results in "***789"
   /// </summary>
   [LogMasked(ShowLast: 3)]
   public string ShowLastThreeThenDefaultMasked { get; set; }
   
   /// <summary>
-  ///  123456789 results in "123######"
+  /// 123456789 results in "******789"
   /// </summary>
-  [LogMasked(Mask: '#', ShowFirst: 3)]
+  [LogMasked(ShowLast: 3, PreserveLength = true)]
+  public string ShowLastThreeThenDefaultMaskedPreserveLength  { get; set; }
+
+  /// <summary>
+  ///  123456789 results in "123REMOVED"
+  /// </summary>
+  [LogMasked(Text: "REMOVED", ShowFirst: 3)]
   public string ShowFirstThreeThenCustomMask { get; set; }
 
   /// <summary>
-  ///  123456789 results in "######789"
+  ///  123456789 results in "REMOVED789"
   /// </summary>
-  [LogMasked(Mask: '#', ShowLast: 3)]
+  [LogMasked(Text: "REMOVED", ShowLast: 3)]
   public string ShowLastThreeThenCustomMask { get; set; }
   
+  /// <summary>
+  ///  123456789 results in "******789"
+  /// </summary>
+  [LogMasked(ShowLast: 3, PreserveLength = true)]
+  public string ShowLastThreeThenCustomMaskPreserveLength { get; set; }
+
+  /// <summary>
+  ///  123456789 results in "123******"
+  /// </summary>
+  [LogMasked(ShowFirst: 3, PreserveLength = true)]
+  public string ShowFirstThreeThenCustomMaskPreserveLength { get; set; }
+
   /// <summary>
   /// 123456789 results in "123***789"
   /// </summary>
@@ -93,9 +124,16 @@ public class Creditcard
   public string ShowFirstAndLastThreeAndDefaultMaskeInTheMiddle { get; set; }
 
   /// <summary>
-  ///  123456789 results in "123###789"
+  ///  123456789 results in "123REMOVED789"
   /// </summary>
-  [LogMasked(Mask: '#', ShowFirst: 3, ShowLast: 3)]
+  [LogMasked(Text: "REMOVED", ShowFirst: 3, ShowLast: 3)]
+  public string ShowFirstAndLastThreeAndCustomMaskInTheMiddle { get; set; }
+
+  /// <summary>
+  ///  NOTE PreserveLength = true is ignored in this case
+  ///  123456789 results in "123REMOVED789"
+  /// </summary>
+  [LogMasked(Text: "REMOVED", ShowFirst: 3, ShowLast: 3, PreserveLength = true)]
   public string ShowFirstAndLastThreeAndCustomMaskInTheMiddle { get; set; }
 }
 ```

--- a/src/Destructurama.Attributed/Attributed/LogMaskedAttribute.cs
+++ b/src/Destructurama.Attributed/Attributed/LogMaskedAttribute.cs
@@ -5,15 +5,30 @@ namespace Destructurama.Attributed
     [AttributeUsage(AttributeTargets.Property)]
     public class LogMaskedAttribute : Attribute
     {
-        public LogMaskedAttribute(char Mask = '*', int ShowFirst = 0, int ShowLast = 0)
+        private const string DefaultMask = "***";
+
+        public LogMaskedAttribute(string Text = DefaultMask, int ShowFirst = 0, int ShowLast = 0, bool PreserveLength = false)
         {
-            this.Mask = Mask;
+            this.Text = Text;
             this.ShowFirst = ShowFirst;
             this.ShowLast = ShowLast;
+            this.PreserveLength = PreserveLength;
         }
 
-        public char Mask { get; }
+        /// <summary>
+        /// Check to see if custom Text has been provided.
+        /// If true PreserveLength is ignored.
+        /// </summary>
+        /// <returns></returns>
+        internal bool IsDefaultMask()
+        {
+            return Text == DefaultMask;
+        }
+
+        public string Text { get; }
         public int ShowFirst { get; }
         public int ShowLast { get; }
+        public bool PreserveLength { get; }
+        public bool PreserveWhitespace { get; }
     }
 }

--- a/src/Destructurama.Attributed/Attributed/LogMaskedAttribute.cs
+++ b/src/Destructurama.Attributed/Attributed/LogMaskedAttribute.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace Destructurama.Attributed
+{
+    [AttributeUsage(AttributeTargets.Property)]
+    public class LogMaskedAttribute : Attribute
+    {
+        public LogMaskedAttribute(char Mask = '*', int ShowFirst = 0, int ShowLast = 0)
+        {
+            this.Mask = Mask;
+            this.ShowFirst = ShowFirst;
+            this.ShowLast = ShowLast;
+        }
+
+        public char Mask { get; }
+        public int ShowFirst { get; }
+        public int ShowLast { get; }
+    }
+}

--- a/test/Destructurama.Attributed.Tests/MaskedAttributeTests.cs
+++ b/test/Destructurama.Attributed.Tests/MaskedAttributeTests.cs
@@ -1,0 +1,318 @@
+﻿using Destructurama.Attributed.Tests.Support;
+using NUnit.Framework;
+using Serilog;
+using Serilog.Events;
+using System;
+using System.Linq;
+
+namespace Destructurama.Attributed.Tests
+{
+    public class CustomizedMaskedLogs
+    {
+        /// <summary>
+        /// 123456789 results in "*********"
+        /// </summary>
+        [LogMasked]
+        public string DefaultMasked { get; set; }
+
+        /// <summary>
+        ///  123456789 results in "#########"
+        /// </summary>
+        [LogMasked(Mask: '#')]
+        public string CustomMasked { get; set; }
+
+        /// <summary>
+        ///  123456789 results in "123******"
+        /// </summary>
+        [LogMasked(ShowFirst: 3)]
+        public string ShowFirstThreeThenDefaultMasked { get; set; }
+
+        /// <summary>
+        /// 123456789 results in "******789"
+        /// </summary>
+        [LogMasked(ShowLast: 3)]
+        public string ShowLastThreeThenDefaultMasked { get; set; }
+
+        /// <summary>
+        ///  123456789 results in "123######"
+        /// </summary>
+        [LogMasked(Mask: '#', ShowFirst: 3)]
+        public string ShowFirstThreeThenCustomMask { get; set; }
+
+        /// <summary>
+        ///  123456789 results in "######789"
+        /// </summary>
+        [LogMasked(Mask: '#', ShowLast: 3)]
+        public string ShowLastThreeThenCustomMask { get; set; }
+
+        /// <summary>
+        /// 123456789 results in "123***789"
+        /// </summary>
+        [LogMasked(ShowFirst: 3, ShowLast: 3)]
+        public string ShowFirstAndLastThreeAndDefaultMaskeInTheMiddle { get; set; }
+
+        /// <summary>
+        ///  123456789 results in "123###789"
+        /// </summary>
+        [LogMasked(Mask: '#', ShowFirst: 3, ShowLast: 3)]
+        public string ShowFirstAndLastThreeAndCustomMaskInTheMiddle { get; set; }
+
+        //[LogMasked(Mask: '#', ShowFirst: 3, ShowLast: 3, MaxMask:10)]
+        //public string ShowLastAndFirstThreeAndCustomMaskeInTheMiddleMaxMask { get; set; }
+    }
+
+    [TestFixture]
+    public class MaskedAttributeTests
+    {
+        [Test]
+        public void LogMaskedAttribute_Replaces_Value_With_DefaultStars_Mask()
+        {
+            // [LogMasked]
+            // 123456789 -> "*********"
+
+            LogEvent evt = null;
+
+            var log = new LoggerConfiguration()
+                .Destructure.UsingAttributes()
+                .WriteTo.Sink(new DelegatingSink(e => evt = e))
+                .CreateLogger();
+
+            var customized = new CustomizedMaskedLogs
+            {
+                DefaultMasked = "123456789"
+            };
+
+            log.Information("Here is {@Customized}", customized);
+
+            var sv = (StructureValue)evt.Properties["Customized"];
+            var props = sv.Properties.ToDictionary(p => p.Name, p => p.Value);
+
+            Assert.IsTrue(props.ContainsKey("DefaultMasked"));
+            Assert.AreEqual("*********", props["DefaultMasked"].LiteralValue());
+        }
+
+        [Test]
+        public void LogMaskedAttribute_Replaces_Value_With_Provided_Mask()
+        {
+            //  [LogMasked(Mask: '#')]
+            //   123456789 -> "#########"
+
+            LogEvent evt = null;
+
+            var log = new LoggerConfiguration()
+                .Destructure.UsingAttributes()
+                .WriteTo.Sink(new DelegatingSink(e => evt = e))
+                .CreateLogger();
+
+            var customized = new CustomizedMaskedLogs
+            {
+                CustomMasked = "123456789"
+            };
+
+            log.Information("Here is {@Customized}", customized);
+
+            var sv = (StructureValue)evt.Properties["Customized"];
+            var props = sv.Properties.ToDictionary(p => p.Name, p => p.Value);
+
+            Assert.IsTrue(props.ContainsKey("CustomMasked"));
+            Assert.AreEqual("#########", props["CustomMasked"].LiteralValue());
+        }
+
+        [Test]
+        public void LogMaskedAttribute_Shows_First_NChars_Then_Replaces_All_With_Custom_Mask()
+        {
+            // [LogMasked(Mask: '#', ShowFirst = 3)]
+            // -> "123######"
+
+            LogEvent evt = null;
+
+            var log = new LoggerConfiguration()
+                .Destructure.UsingAttributes()
+                .WriteTo.Sink(new DelegatingSink(e => evt = e))
+                .CreateLogger();
+
+            var customized = new CustomizedMaskedLogs
+            {
+                ShowFirstThreeThenCustomMask = "123456789"
+            };
+
+            log.Information("Here is {@Customized}", customized);
+
+            var sv = (StructureValue)evt.Properties["Customized"];
+            var props = sv.Properties.ToDictionary(p => p.Name, p => p.Value);
+
+            Assert.IsTrue(props.ContainsKey("ShowFirstThreeThenCustomMask"));
+            Assert.AreEqual("123######", props["ShowFirstThreeThenCustomMask"].LiteralValue());
+        }
+
+        [Test]
+        public void LogMaskedAttribute_Shows_First_NChars_And_Last_NChars_Replaces_Value_With_Default_Mask()
+        {
+            // [LogMasked(ShowFirst = 3, ShowLast = 3)]
+            // -> "1234*********4321"
+
+            LogEvent evt = null;
+
+            var log = new LoggerConfiguration()
+                .Destructure.UsingAttributes()
+                .WriteTo.Sink(new DelegatingSink(e => evt = e))
+                .CreateLogger();
+
+            var customized = new CustomizedMaskedLogs
+            {
+                ShowFirstAndLastThreeAndDefaultMaskeInTheMiddle = "12345678987654321"
+            };
+
+            log.Information("Here is {@Customized}", customized);
+
+            var sv = (StructureValue)evt.Properties["Customized"];
+            var props = sv.Properties.ToDictionary(p => p.Name, p => p.Value);
+
+            Assert.IsTrue(props.ContainsKey("ShowFirstAndLastThreeAndDefaultMaskeInTheMiddle"));
+            Assert.AreEqual("123***********321", props["ShowFirstAndLastThreeAndDefaultMaskeInTheMiddle"].LiteralValue());
+        }
+
+        [Test]
+        public void LogMaskedAttribute_Shows_First_NChars_And_Last_NChars_Then_Replaces_All_Other_Chars_With_Provided_Mask()
+        {
+            // [LogMasked(Mask: '#', ShowFirst = 3, ShowLast = 3)]
+            // 12345678987654321 -> "123###########321"
+
+            LogEvent evt = null;
+
+            var log = new LoggerConfiguration()
+                .Destructure.UsingAttributes()
+                .WriteTo.Sink(new DelegatingSink(e => evt = e))
+                .CreateLogger();
+
+            var customized = new CustomizedMaskedLogs
+            {
+                ShowFirstAndLastThreeAndCustomMaskInTheMiddle = "12345678987654321"
+            };
+
+            log.Information("Here is {@Customized}", customized);
+
+            var sv = (StructureValue)evt.Properties["Customized"];
+            var props = sv.Properties.ToDictionary(p => p.Name, p => p.Value);
+
+            Assert.IsTrue(props.ContainsKey("ShowFirstAndLastThreeAndCustomMaskInTheMiddle"));
+            Assert.AreEqual("123###########321", props["ShowFirstAndLastThreeAndCustomMaskInTheMiddle"].LiteralValue());
+        }
+
+        [Test]
+        public void LogMaskedAttribute_Shows_First_NChars_Then_Replaces_All_Other_Chars_With_Default_Mask()
+        {
+            //  [LogMasked(ShowLast = 3)]
+            //  123456789 -> "123******"
+
+            LogEvent evt = null;
+
+            var log = new LoggerConfiguration()
+                .Destructure.UsingAttributes()
+                .WriteTo.Sink(new DelegatingSink(e => evt = e))
+                .CreateLogger();
+
+            var customized = new CustomizedMaskedLogs
+            {
+                ShowFirstThreeThenDefaultMasked = "123456789"
+            };
+
+            log.Information("Here is {@Customized}", customized);
+
+            var sv = (StructureValue)evt.Properties["Customized"];
+            var props = sv.Properties.ToDictionary(p => p.Name, p => p.Value);
+
+            Assert.IsTrue(props.ContainsKey("ShowFirstThreeThenDefaultMasked"));
+            Assert.AreEqual("123******", props["ShowFirstThreeThenDefaultMasked"].LiteralValue());
+        }
+
+        [Test]
+        public void LogMaskedAttribute_Shows_Last_NChars_Then_Replaces_All_Other_Chars_With_Custom_Mask()
+        {
+            //  [LogMasked(Mask: '#', ShowLast = 3)]
+            //  123456789 -> "######789"
+
+            LogEvent evt = null;
+
+            var log = new LoggerConfiguration()
+                .Destructure.UsingAttributes()
+                .WriteTo.Sink(new DelegatingSink(e => evt = e))
+                .CreateLogger();
+
+            var customized = new CustomizedMaskedLogs
+            {
+                ShowLastThreeThenCustomMask = "123456789"
+            };
+
+            log.Information("Here is {@Customized}", customized);
+
+            var sv = (StructureValue)evt.Properties["Customized"];
+            var props = sv.Properties.ToDictionary(p => p.Name, p => p.Value);
+
+            Assert.IsTrue(props.ContainsKey("ShowLastThreeThenCustomMask"));
+            Assert.AreEqual("######789", props["ShowLastThreeThenCustomMask"].LiteralValue());
+        }
+
+        [Test]
+        public void LogMaskedAttribute_Shows_Last_NChars_Then_Replaces_All_Other_Chars_With_Provided_Mask()
+        {
+            //  [LogMasked(Text = "####", ShowLast = 4)]
+            // -> "("*****6789"
+
+            LogEvent evt = null;
+
+            var log = new LoggerConfiguration()
+                .Destructure.UsingAttributes()
+                .WriteTo.Sink(new DelegatingSink(e => evt = e))
+                .CreateLogger();
+
+            var customized = new CustomizedMaskedLogs
+            {
+                ShowLastThreeThenDefaultMasked = "123456789"
+            };
+
+            log.Information("Here is {@Customized}", customized);
+
+            var sv = (StructureValue)evt.Properties["Customized"];
+            var props = sv.Properties.ToDictionary(p => p.Name, p => p.Value);
+
+            Assert.IsTrue(props.ContainsKey("ShowLastThreeThenDefaultMasked"));
+            Assert.AreEqual("******789", props["ShowLastThreeThenDefaultMasked"].LiteralValue());
+        }
+
+        /// <summary>
+        /// This was just a thought. Maby the user wants to limit the lenght of masked value to some max value.
+        /// E.g JWT token... maby you just want to log the first 20 and last 20 but not everything.
+        /// </summary>
+        //[Test]
+        public void LogMaskedAttribute_Shows_First_NChars_And_Last_NChars_Then_Replaces_All_Other_Chars_With_Provided_Mask_But_Only_Max_Mask()
+        {
+            // [LogMasked(Text = "#####", ShowFirst = 3, ShowLast = 3, MaxMask = 10)]
+            // -> "123##########321"
+
+            throw new NotImplementedException("Just a thought to limit the mask to some number");
+
+            LogEvent evt = null;
+
+            var log = new LoggerConfiguration()
+                .Destructure.UsingAttributes()
+                .WriteTo.Sink(new DelegatingSink(e => evt = e))
+                .CreateLogger();
+
+            var customized = new CustomizedMaskedLogs
+            {
+                // ShowLastAndFirstThreeAndCustomMaskeInTheMiddleMaxMask = "12345678987654321123456789876543211234567898765432112345678987654321"
+            };
+
+            log.Information("Here is {@Customized}", customized);
+
+            var sv = (StructureValue)evt.Properties["Customized"];
+            var props = sv.Properties.ToDictionary(p => p.Name, p => p.Value);
+
+            Assert.IsTrue(props.ContainsKey("ShowLastAndFirstThreeAndCustomMaskeInTheMiddleMaxMask"));
+            Assert.AreEqual("123##########321", props["ShowLastAndFirstThreeAndCustomMaskeInTheMiddleMaxMask"].LiteralValue());
+        }
+    }
+}
+
+

--- a/test/Destructurama.Attributed.Tests/MaskedAttributeTests.cs
+++ b/test/Destructurama.Attributed.Tests/MaskedAttributeTests.cs
@@ -10,16 +10,28 @@ namespace Destructurama.Attributed.Tests
     public class CustomizedMaskedLogs
     {
         /// <summary>
-        /// 123456789 results in "*********"
+        /// 123456789 results in "***"
         /// </summary>
         [LogMasked]
         public string DefaultMasked { get; set; }
 
         /// <summary>
+        /// 123456789 results in "*********"
+        /// </summary>
+        [LogMasked(PreserveLength: true)]
+        public string DefaultMaskedPreserved { get; set; }
+
+        /// <summary>
+        ///  123456789 results in "#"
+        /// </summary>
+        [LogMasked(Text: "_REMOVED_")]
+        public string CustomMasked { get; set; }
+
+        /// <summary>
         ///  123456789 results in "#########"
         /// </summary>
-        [LogMasked(Mask: '#')]
-        public string CustomMasked { get; set; }
+        [LogMasked(Text: "#", PreserveLength: true)]
+        public string CustomMaskedPreservedLenght { get; set; }
 
         /// <summary>
         ///  123456789 results in "123******"
@@ -28,22 +40,46 @@ namespace Destructurama.Attributed.Tests
         public string ShowFirstThreeThenDefaultMasked { get; set; }
 
         /// <summary>
-        /// 123456789 results in "******789"
+        /// 123456789 results in "123******"
+        /// </summary>
+        [LogMasked(ShowFirst: 3, PreserveLength: true)]
+        public string ShowFirstThreeThenDefaultMaskedPreservedLenght { get; set; }
+
+        /// <summary>
+        /// 123456789 results in "***789"
         /// </summary>
         [LogMasked(ShowLast: 3)]
         public string ShowLastThreeThenDefaultMasked { get; set; }
 
         /// <summary>
-        ///  123456789 results in "123######"
+        /// 123456789 results in "******789"
         /// </summary>
-        [LogMasked(Mask: '#', ShowFirst: 3)]
+        [LogMasked(ShowLast: 3, PreserveLength: true)]
+        public string ShowLastThreeThenDefaultMaskedPreservedLenght { get; set; }
+
+        /// <summary>
+        ///  123456789 results in "123REMOVED"
+        /// </summary>
+        [LogMasked(Text: "_REMOVED_", ShowFirst: 3)]
         public string ShowFirstThreeThenCustomMask { get; set; }
 
         /// <summary>
-        ///  123456789 results in "######789"
+        ///  123456789 results in "123_REMOVED_"
         /// </summary>
-        [LogMasked(Mask: '#', ShowLast: 3)]
+        [LogMasked(Text: "_REMOVED_", ShowFirst: 3, PreserveLength: true)]
+        public string ShowFirstThreeThenCustomMaskPreservedLenghtIgnored { get; set; }
+
+        /// <summary>
+        ///  123456789 results in "_REMOVED_789"
+        /// </summary>
+        [LogMasked(Text: "_REMOVED_", ShowLast: 3)]
         public string ShowLastThreeThenCustomMask { get; set; }
+
+        /// <summary>
+        ///  123456789 results in "_REMOVED_789"
+        /// </summary>
+        [LogMasked(Text: "_REMOVED_", ShowLast: 3, PreserveLength: true)]
+        public string ShowLastThreeThenCustomMaskPreservedLenghtIgnored { get; set; }
 
         /// <summary>
         /// 123456789 results in "123***789"
@@ -52,13 +88,16 @@ namespace Destructurama.Attributed.Tests
         public string ShowFirstAndLastThreeAndDefaultMaskeInTheMiddle { get; set; }
 
         /// <summary>
-        ///  123456789 results in "123###789"
+        ///  123456789 results in "123_REMOVED_789                                                                                                                                                                                                                                                                                                                <               °                       °    °                                         °                     789"
         /// </summary>
-        [LogMasked(Mask: '#', ShowFirst: 3, ShowLast: 3)]
+        [LogMasked(Text: "_REMOVED_", ShowFirst: 3, ShowLast: 3)]
         public string ShowFirstAndLastThreeAndCustomMaskInTheMiddle { get; set; }
 
-        //[LogMasked(Mask: '#', ShowFirst: 3, ShowLast: 3, MaxMask:10)]
-        //public string ShowLastAndFirstThreeAndCustomMaskeInTheMiddleMaxMask { get; set; }
+        /// <summary>
+        ///  123456789 results in "123_REMOVED_789". PreserveLenght is ignored                                                                                                                                                                                                                                                                                                          <               °                       °    °                                         °                     789"
+        /// </summary>
+        [LogMasked(Text: "_REMOVED_", ShowFirst: 3, ShowLast: 3, PreserveLength: true)]
+        public string ShowFirstAndLastThreeAndCustomMaskInTheMiddlePreservedLenghtIgnored { get; set; }
     }
 
     [TestFixture]
@@ -68,7 +107,7 @@ namespace Destructurama.Attributed.Tests
         public void LogMaskedAttribute_Replaces_Value_With_DefaultStars_Mask()
         {
             // [LogMasked]
-            // 123456789 -> "*********"
+            // 123456789 -> "***"
 
             LogEvent evt = null;
 
@@ -88,14 +127,41 @@ namespace Destructurama.Attributed.Tests
             var props = sv.Properties.ToDictionary(p => p.Name, p => p.Value);
 
             Assert.IsTrue(props.ContainsKey("DefaultMasked"));
-            Assert.AreEqual("*********", props["DefaultMasked"].LiteralValue());
+            Assert.AreEqual("***", props["DefaultMasked"].LiteralValue());
+        }
+
+        [Test]
+        public void LogMaskedAttribute_Replaces_Value_With_DefaultStars_Mask_And_PreservedLenght()
+        {
+            // [LogMasked]
+            // 123456789 -> "*********"
+
+            LogEvent evt = null;
+
+            var log = new LoggerConfiguration()
+                .Destructure.UsingAttributes()
+                .WriteTo.Sink(new DelegatingSink(e => evt = e))
+                .CreateLogger();
+
+            var customized = new CustomizedMaskedLogs
+            {
+                DefaultMaskedPreserved = "123456789"
+            };
+
+            log.Information("Here is {@Customized}", customized);
+
+            var sv = (StructureValue)evt.Properties["Customized"];
+            var props = sv.Properties.ToDictionary(p => p.Name, p => p.Value);
+
+            Assert.IsTrue(props.ContainsKey("DefaultMaskedPreserved"));
+            Assert.AreEqual("*********", props["DefaultMaskedPreserved"].LiteralValue());
         }
 
         [Test]
         public void LogMaskedAttribute_Replaces_Value_With_Provided_Mask()
         {
-            //  [LogMasked(Mask: '#')]
-            //   123456789 -> "#########"
+            //  [LogMasked(Text: "#")]
+            //   123456789 -> "_REMOVED_"
 
             LogEvent evt = null;
 
@@ -115,14 +181,41 @@ namespace Destructurama.Attributed.Tests
             var props = sv.Properties.ToDictionary(p => p.Name, p => p.Value);
 
             Assert.IsTrue(props.ContainsKey("CustomMasked"));
-            Assert.AreEqual("#########", props["CustomMasked"].LiteralValue());
+            Assert.AreEqual("_REMOVED_", props["CustomMasked"].LiteralValue());
+        }
+
+        [Test]
+        public void LogMaskedAttribute_Replaces_Value_With_Provided_Mask_And_PreservedLenght()
+        {
+            //  [LogMasked(Text: "#")]
+            //   123456789 -> "#########"
+
+            LogEvent evt = null;
+
+            var log = new LoggerConfiguration()
+                .Destructure.UsingAttributes()
+                .WriteTo.Sink(new DelegatingSink(e => evt = e))
+                .CreateLogger();
+
+            var customized = new CustomizedMaskedLogs
+            {
+                CustomMaskedPreservedLenght = "123456789"
+            };
+
+            log.Information("Here is {@Customized}", customized);
+
+            var sv = (StructureValue)evt.Properties["Customized"];
+            var props = sv.Properties.ToDictionary(p => p.Name, p => p.Value);
+
+            Assert.IsTrue(props.ContainsKey("CustomMaskedPreservedLenght"));
+            Assert.AreEqual("#########", props["CustomMaskedPreservedLenght"].LiteralValue());
         }
 
         [Test]
         public void LogMaskedAttribute_Shows_First_NChars_Then_Replaces_All_With_Custom_Mask()
         {
-            // [LogMasked(Mask: '#', ShowFirst = 3)]
-            // -> "123######"
+            // [LogMasked(Text: "REMOVED", ShowFirst = 3)]
+            // -> "123_REMOVED_"
 
             LogEvent evt = null;
 
@@ -142,11 +235,38 @@ namespace Destructurama.Attributed.Tests
             var props = sv.Properties.ToDictionary(p => p.Name, p => p.Value);
 
             Assert.IsTrue(props.ContainsKey("ShowFirstThreeThenCustomMask"));
-            Assert.AreEqual("123######", props["ShowFirstThreeThenCustomMask"].LiteralValue());
+            Assert.AreEqual("123_REMOVED_", props["ShowFirstThreeThenCustomMask"].LiteralValue());
         }
 
         [Test]
-        public void LogMaskedAttribute_Shows_First_NChars_And_Last_NChars_Replaces_Value_With_Default_Mask()
+        public void LogMaskedAttribute_Shows_First_NChars_Then_Replaces_All_With_Custom_Mask_PreservedLenght_Ignored()
+        {
+            // [LogMasked(Text: "REMOVED", ShowFirst = 3,PreserveLenght = true)]
+            // -> "123_REMOVED_"
+
+            LogEvent evt = null;
+
+            var log = new LoggerConfiguration()
+                .Destructure.UsingAttributes()
+                .WriteTo.Sink(new DelegatingSink(e => evt = e))
+                .CreateLogger();
+
+            var customized = new CustomizedMaskedLogs
+            {
+                ShowFirstThreeThenCustomMaskPreservedLenghtIgnored = "123456789"
+            };
+
+            log.Information("Here is {@Customized}", customized);
+
+            var sv = (StructureValue)evt.Properties["Customized"];
+            var props = sv.Properties.ToDictionary(p => p.Name, p => p.Value);
+
+            Assert.IsTrue(props.ContainsKey("ShowFirstThreeThenCustomMaskPreservedLenghtIgnored"));
+            Assert.AreEqual("123_REMOVED_", props["ShowFirstThreeThenCustomMaskPreservedLenghtIgnored"].LiteralValue());
+        }
+
+        [Test]
+        public void LogMaskedAttribute_Shows_First_NChars_And_Last_NChars_Replaces_Value_With_Default_StarMask()
         {
             // [LogMasked(ShowFirst = 3, ShowLast = 3)]
             // -> "1234*********4321"
@@ -169,14 +289,14 @@ namespace Destructurama.Attributed.Tests
             var props = sv.Properties.ToDictionary(p => p.Name, p => p.Value);
 
             Assert.IsTrue(props.ContainsKey("ShowFirstAndLastThreeAndDefaultMaskeInTheMiddle"));
-            Assert.AreEqual("123***********321", props["ShowFirstAndLastThreeAndDefaultMaskeInTheMiddle"].LiteralValue());
+            Assert.AreEqual("123***321", props["ShowFirstAndLastThreeAndDefaultMaskeInTheMiddle"].LiteralValue());
         }
 
         [Test]
-        public void LogMaskedAttribute_Shows_First_NChars_And_Last_NChars_Then_Replaces_All_Other_Chars_With_Provided_Mask()
+        public void LogMaskedAttribute_Shows_First_NChars_And_Last_NChars_Then_Replaces_All_Other_Chars_With_Custom_Mask()
         {
-            // [LogMasked(Mask: '#', ShowFirst = 3, ShowLast = 3)]
-            // 12345678987654321 -> "123###########321"
+            // [LogMasked(Text: "REMOVED", ShowFirst = 3, ShowLast = 3)]
+            // 12345678987654321 -> 123_REMOVED_321     
 
             LogEvent evt = null;
 
@@ -196,14 +316,41 @@ namespace Destructurama.Attributed.Tests
             var props = sv.Properties.ToDictionary(p => p.Name, p => p.Value);
 
             Assert.IsTrue(props.ContainsKey("ShowFirstAndLastThreeAndCustomMaskInTheMiddle"));
-            Assert.AreEqual("123###########321", props["ShowFirstAndLastThreeAndCustomMaskInTheMiddle"].LiteralValue());
+            Assert.AreEqual("123_REMOVED_321", props["ShowFirstAndLastThreeAndCustomMaskInTheMiddle"].LiteralValue());
         }
 
         [Test]
-        public void LogMaskedAttribute_Shows_First_NChars_Then_Replaces_All_Other_Chars_With_Default_Mask()
+        public void LogMaskedAttribute_Shows_First_NChars_And_Last_NChars_Then_Replaces_All_Other_Chars_With_Custom_Mask_And_PreservedLenght()
+        {
+            // [LogMasked(Text: "#", ShowFirst = 3, ShowLast = 3)]
+            // 12345678987654321 -> "123_REMOVED_321"
+
+            LogEvent evt = null;
+
+            var log = new LoggerConfiguration()
+                .Destructure.UsingAttributes()
+                .WriteTo.Sink(new DelegatingSink(e => evt = e))
+                .CreateLogger();
+
+            var customized = new CustomizedMaskedLogs
+            {
+                ShowFirstAndLastThreeAndCustomMaskInTheMiddle = "12345678987654321"
+            };
+
+            log.Information("Here is {@Customized}", customized);
+
+            var sv = (StructureValue)evt.Properties["Customized"];
+            var props = sv.Properties.ToDictionary(p => p.Name, p => p.Value);
+
+            Assert.IsTrue(props.ContainsKey("ShowFirstAndLastThreeAndCustomMaskInTheMiddle"));
+            Assert.AreEqual("123_REMOVED_321", props["ShowFirstAndLastThreeAndCustomMaskInTheMiddle"].LiteralValue());
+        }
+
+        [Test]
+        public void LogMaskedAttribute_Shows_First_NChars_Then_Replaces_All_Other_Chars_With_Default_StarMask()
         {
             //  [LogMasked(ShowLast = 3)]
-            //  123456789 -> "123******"
+            //  123456789 -> "123***"
 
             LogEvent evt = null;
 
@@ -223,14 +370,14 @@ namespace Destructurama.Attributed.Tests
             var props = sv.Properties.ToDictionary(p => p.Name, p => p.Value);
 
             Assert.IsTrue(props.ContainsKey("ShowFirstThreeThenDefaultMasked"));
-            Assert.AreEqual("123******", props["ShowFirstThreeThenDefaultMasked"].LiteralValue());
+            Assert.AreEqual("123***", props["ShowFirstThreeThenDefaultMasked"].LiteralValue());
         }
 
         [Test]
         public void LogMaskedAttribute_Shows_Last_NChars_Then_Replaces_All_Other_Chars_With_Custom_Mask()
         {
-            //  [LogMasked(Mask: '#', ShowLast = 3)]
-            //  123456789 -> "######789"
+            //  [LogMasked(Text: "_REMOVED_", ShowLast = 3)]
+            //  123456789 -> "_REMOVED_789"
 
             LogEvent evt = null;
 
@@ -250,14 +397,41 @@ namespace Destructurama.Attributed.Tests
             var props = sv.Properties.ToDictionary(p => p.Name, p => p.Value);
 
             Assert.IsTrue(props.ContainsKey("ShowLastThreeThenCustomMask"));
-            Assert.AreEqual("######789", props["ShowLastThreeThenCustomMask"].LiteralValue());
+            Assert.AreEqual("_REMOVED_789", props["ShowLastThreeThenCustomMask"].LiteralValue());
         }
 
         [Test]
-        public void LogMaskedAttribute_Shows_Last_NChars_Then_Replaces_All_Other_Chars_With_Provided_Mask()
+        public void LogMaskedAttribute_Shows_Last_NChars_Then_Replaces_All_Other_Chars_With_Custom_Mask_PreserveLength_Ignored()
         {
-            //  [LogMasked(Text = "####", ShowLast = 4)]
-            // -> "("*****6789"
+            //  [LogMasked(Text: "_REMOVED_", ShowLast = 3, PreserveLength = true)]
+            //  123456789 -> "_REMOVED_789"
+
+            LogEvent evt = null;
+
+            var log = new LoggerConfiguration()
+                .Destructure.UsingAttributes()
+                .WriteTo.Sink(new DelegatingSink(e => evt = e))
+                .CreateLogger();
+
+            var customized = new CustomizedMaskedLogs
+            {
+                ShowLastThreeThenCustomMaskPreservedLenghtIgnored = "123456789"
+            };
+
+            log.Information("Here is {@Customized}", customized);
+
+            var sv = (StructureValue)evt.Properties["Customized"];
+            var props = sv.Properties.ToDictionary(p => p.Name, p => p.Value);
+
+            Assert.IsTrue(props.ContainsKey("ShowLastThreeThenCustomMaskPreservedLenghtIgnored"));
+            Assert.AreEqual("_REMOVED_789", props["ShowLastThreeThenCustomMaskPreservedLenghtIgnored"].LiteralValue());
+        }
+
+        [Test]
+        public void LogMaskedAttribute_Shows_Last_NChars_Then_Replaces_All_Other_Chars_With_Default_StarMask()
+        {
+            //  [LogMasked(ShowLast = 3)]
+            //  123456789 -> "***789"
 
             LogEvent evt = null;
 
@@ -277,20 +451,14 @@ namespace Destructurama.Attributed.Tests
             var props = sv.Properties.ToDictionary(p => p.Name, p => p.Value);
 
             Assert.IsTrue(props.ContainsKey("ShowLastThreeThenDefaultMasked"));
-            Assert.AreEqual("******789", props["ShowLastThreeThenDefaultMasked"].LiteralValue());
+            Assert.AreEqual("***789", props["ShowLastThreeThenDefaultMasked"].LiteralValue());
         }
 
-        /// <summary>
-        /// This was just a thought. Maby the user wants to limit the lenght of masked value to some max value.
-        /// E.g JWT token... maby you just want to log the first 20 and last 20 but not everything.
-        /// </summary>
-        //[Test]
-        public void LogMaskedAttribute_Shows_First_NChars_And_Last_NChars_Then_Replaces_All_Other_Chars_With_Provided_Mask_But_Only_Max_Mask()
+        [Test]
+        public void LogMaskedAttribute_Shows_First_NChars_Then_Replaces_All_Other_Chars_With_Default_StarMask_And_PreservedLenght()
         {
-            // [LogMasked(Text = "#####", ShowFirst = 3, ShowLast = 3, MaxMask = 10)]
-            // -> "123##########321"
-
-            throw new NotImplementedException("Just a thought to limit the mask to some number");
+            //  [LogMasked(ShowFirst = 3,PreserveLength: true))]
+            // -> "123******"
 
             LogEvent evt = null;
 
@@ -301,7 +469,7 @@ namespace Destructurama.Attributed.Tests
 
             var customized = new CustomizedMaskedLogs
             {
-                // ShowLastAndFirstThreeAndCustomMaskeInTheMiddleMaxMask = "12345678987654321123456789876543211234567898765432112345678987654321"
+                ShowFirstThreeThenDefaultMaskedPreservedLenght = "123456789"
             };
 
             log.Information("Here is {@Customized}", customized);
@@ -309,8 +477,62 @@ namespace Destructurama.Attributed.Tests
             var sv = (StructureValue)evt.Properties["Customized"];
             var props = sv.Properties.ToDictionary(p => p.Name, p => p.Value);
 
-            Assert.IsTrue(props.ContainsKey("ShowLastAndFirstThreeAndCustomMaskeInTheMiddleMaxMask"));
-            Assert.AreEqual("123##########321", props["ShowLastAndFirstThreeAndCustomMaskeInTheMiddleMaxMask"].LiteralValue());
+            Assert.IsTrue(props.ContainsKey("ShowFirstThreeThenDefaultMaskedPreservedLenght"));
+            Assert.AreEqual("123******", props["ShowFirstThreeThenDefaultMaskedPreservedLenght"].LiteralValue());
+        }
+
+        [Test]
+        public void LogMaskedAttribute_Shows_Last_NChars_Then_Replaces_All_Other_Chars_With_Default_StarMask_And_PreservedLenght()
+        {
+            //  [LogMasked(ShowLast = 3,PreserveLength: true))]
+            // -> "******789"
+
+            LogEvent evt = null;
+
+            var log = new LoggerConfiguration()
+                .Destructure.UsingAttributes()
+                .WriteTo.Sink(new DelegatingSink(e => evt = e))
+                .CreateLogger();
+
+            var customized = new CustomizedMaskedLogs
+            {
+                ShowLastThreeThenDefaultMaskedPreservedLenght = "123456789"
+            };
+
+            log.Information("Here is {@Customized}", customized);
+
+            var sv = (StructureValue)evt.Properties["Customized"];
+            var props = sv.Properties.ToDictionary(p => p.Name, p => p.Value);
+
+            Assert.IsTrue(props.ContainsKey("ShowLastThreeThenDefaultMaskedPreservedLenght"));
+            Assert.AreEqual("******789", props["ShowLastThreeThenDefaultMaskedPreservedLenght"].LiteralValue());
+        }
+
+        [Test]
+        public void LogMaskedAttribute_Shows_First_NChars_And_Last_NChars_Then_Replaces_All_Other_Chars_With_Custom_Mask_And_PreservedLenght_That_Gives_Warning()
+        {
+            // [LogMasked(Text: "REMOVED", ShowFirst = 3, ShowLast = 3, PreserveLength = true)]
+            // 12345678987654321 -> 123_REMOVED_321 
+
+            LogEvent evt = null;
+
+            var log = new LoggerConfiguration()
+                .Destructure.UsingAttributes()
+                .WriteTo.Sink(new DelegatingSink(e => evt = e))
+                .CreateLogger();
+
+            var customized = new CustomizedMaskedLogs
+            {
+                ShowFirstAndLastThreeAndCustomMaskInTheMiddlePreservedLenghtIgnored = "12345678987654321"
+            };
+
+            log.Information("Here is {@Customized}", customized);
+
+            var sv = (StructureValue)evt.Properties["Customized"];
+            var props = sv.Properties.ToDictionary(p => p.Name, p => p.Value);
+
+            Assert.IsTrue(props.ContainsKey("ShowFirstAndLastThreeAndCustomMaskInTheMiddlePreservedLenghtIgnored"));
+            Assert.AreEqual("123_REMOVED_321", props["ShowFirstAndLastThreeAndCustomMaskInTheMiddlePreservedLenghtIgnored"].LiteralValue());
         }
     }
 }


### PR DESCRIPTION
Well here it goes.. I had to copy everything over to the fork :-) And I think this pull request is going to land at your end.

I deviated (from our talk in #14)  a little in the implementation but only for Text ="##" to Mask = '#'. That way you will retain the number of chars in a string that are masked.

Since this is a .net standard project I was unable to profile the unittests to try to find bottlenecks. Since the base code is yours you understand it enough to be able increase performance (each unittest takes 2-3 ms after the first one taking up to 17 ms). I don´t know what is acceptable but I tried to make it as fast as I could. There is nothing to fancy in there from me.  

You just let me know what could be done better/different.

Best Regards
Sturla