### PR TITLE
The entire input should be returned when ShowFirst + ShowLast is greater than the length of the input

### DIFF
--- a/src/Destructurama.Attributed/Attributed/AttributedDestructuringPolicy.cs
+++ b/src/Destructurama.Attributed/Attributed/AttributedDestructuringPolicy.cs
@@ -200,10 +200,15 @@ namespace Destructurama.Attributed
             }
             else if (attribute.ShowFirst > 0 && attribute.ShowLast > 0)
             {
-                var first = val.Substring(0, attribute.ShowFirst);
-                var last = val.Substring(val.Length - attribute.ShowLast);
+                if (attribute.ShowFirst + attribute.ShowLast >= val.Length)
+                    propValue = val;
+                else
+                {
+                    var first = val.Substring(0, attribute.ShowFirst);
+                    var last = val.Substring(val.Length - attribute.ShowLast);
 
-                propValue = first + attribute.Text + last;
+                    propValue = first + attribute.Text + last;
+                }
             }
         }
     }

--- a/test/Destructurama.Attributed.Tests/MaskedAttributeTests.cs
+++ b/test/Destructurama.Attributed.Tests/MaskedAttributeTests.cs
@@ -347,6 +347,60 @@ namespace Destructurama.Attributed.Tests
         }
 
         [Test]
+        public void LogMaskedAttribute_Shows_First_NChars_And_Last_NChars_Then_Replaces_All_Other_Chars_With_Custom_Mask_And_PreservedLength_Even_When_Input_Length_Is_Less_Than_ShowFirst()
+        {
+            // [LogMasked(Text: "#", ShowFirst = 3, ShowLast = 3)]
+            // 12 -> "12"
+
+            LogEvent evt = null;
+
+            var log = new LoggerConfiguration()
+                .Destructure.UsingAttributes()
+                .WriteTo.Sink(new DelegatingSink(e => evt = e))
+                .CreateLogger();
+
+            var customized = new CustomizedMaskedLogs
+            {
+                ShowFirstAndLastThreeAndCustomMaskInTheMiddle = "12"
+            };
+
+            log.Information("Here is {@Customized}", customized);
+
+            var sv = (StructureValue)evt.Properties["Customized"];
+            var props = sv.Properties.ToDictionary(p => p.Name, p => p.Value);
+
+            Assert.IsTrue(props.ContainsKey("ShowFirstAndLastThreeAndCustomMaskInTheMiddle"));
+            Assert.AreEqual("12", props["ShowFirstAndLastThreeAndCustomMaskInTheMiddle"].LiteralValue());
+        }
+
+        [Test]
+        public void LogMaskedAttribute_Shows_First_NChars_And_Last_NChars_Then_Replaces_All_Other_Chars_With_Custom_Mask_And_PreservedLength_Even_When_Input_Length_Is_Less_Than_ShowFirst_Plus_ShowLast()
+        {
+            // [LogMasked(Text: "#", ShowFirst = 3, ShowLast = 3)]
+            // 1234 -> "1234"
+
+            LogEvent evt = null;
+
+            var log = new LoggerConfiguration()
+                .Destructure.UsingAttributes()
+                .WriteTo.Sink(new DelegatingSink(e => evt = e))
+                .CreateLogger();
+
+            var customized = new CustomizedMaskedLogs
+            {
+                ShowFirstAndLastThreeAndCustomMaskInTheMiddle = "1234"
+            };
+
+            log.Information("Here is {@Customized}", customized);
+
+            var sv = (StructureValue)evt.Properties["Customized"];
+            var props = sv.Properties.ToDictionary(p => p.Name, p => p.Value);
+
+            Assert.IsTrue(props.ContainsKey("ShowFirstAndLastThreeAndCustomMaskInTheMiddle"));
+            Assert.AreEqual("1234", props["ShowFirstAndLastThreeAndCustomMaskInTheMiddle"].LiteralValue());
+        }
+
+        [Test]
         public void LogMaskedAttribute_Shows_First_NChars_Then_Replaces_All_Other_Chars_With_Default_StarMask()
         {
             //  [LogMasked(ShowLast = 3)]


### PR DESCRIPTION
As a followup on @nblumhardt's comment on a previous pull request (https://github.com/destructurama/attributed/pull/19#issuecomment-363663352) I've made some corrections so the code doesn't return a value greater than the given input. 

So when ShowFirst + ShowLast is greater than the length of the given input, the entire input is returned.