### PR TITLE
Code tidy-up

### DIFF
--- a/src/Destructurama.Attributed/Attributed/DestructuringAttribute.cs
+++ b/src/Destructurama.Attributed/Attributed/DestructuringAttribute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2015 Destructurama Contributors, Serilog Contributors
+﻿// Copyright 2018 Destructurama Contributors, Serilog Contributors
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Destructurama.Attributed/Attributed/LogMaskedAttribute.cs
+++ b/src/Destructurama.Attributed/Attributed/LogMaskedAttribute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2015 Destructurama Contributors, Serilog Contributors
+﻿// Copyright 2015-2018 Destructurama Contributors, Serilog Contributors
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,15 +21,12 @@ namespace Destructurama.Attributed
     [AttributeUsage(AttributeTargets.Property)]
     public class LogMaskedAttribute : DestructuringAttribute
     {
-        private const string DefaultMask = "***";
+        const string DefaultMask = "***";
 
-        public LogMaskedAttribute(string Text = DefaultMask, int ShowFirst = 0, int ShowLast = 0, bool PreserveLength = false)
-        {
-            this.Text = Text;
-            this.ShowFirst = ShowFirst;
-            this.ShowLast = ShowLast;
-            this.PreserveLength = PreserveLength;
-        }
+        public string Text { get; set; } = DefaultMask;
+        public int ShowFirst { get; set; }
+        public int ShowLast { get; set; }
+        public bool PreserveLength { get; set; }
 
         /// <summary>
         /// Check to see if custom Text has been provided.
@@ -41,11 +38,6 @@ namespace Destructurama.Attributed
             return Text == DefaultMask;
         }
 
-        private string Text { get; }
-        private int ShowFirst { get; }
-        private int ShowLast { get; }
-        private bool PreserveLength { get; }
-
         internal object FormatMaskedValue(object propValue)
         {
             var val = propValue as string;
@@ -56,7 +48,7 @@ namespace Destructurama.Attributed
             if (ShowFirst == 0 && ShowLast == 0)
             {
                 if (PreserveLength)
-                    return new String(Text[0], val.Length);
+                    return new string(Text[0], val.Length);
 
                 return Text;
             }
@@ -65,37 +57,29 @@ namespace Destructurama.Attributed
             {
                 var first = val.Substring(0, Math.Min(ShowFirst, val.Length));
 
-                if (PreserveLength && IsDefaultMask())
-                {
-                    string mask;
-                    if (ShowFirst > val.Length)
-                        mask = "";
-                    else
-                        mask = new String(Text[0], val.Length - ShowFirst);
-                    return first + mask;
-                }
+                if (!PreserveLength || !IsDefaultMask())
+                    return first + Text;
 
-                return first + Text;
+                var mask = "";
+                if (ShowFirst <= val.Length)
+                    mask = new string(Text[0], val.Length - ShowFirst);
+
+                return first + mask;
+
             }
 
             if (ShowFirst == 0 && ShowLast > 0)
             {
-                string last;
-                if (ShowLast > val.Length)
-                    last = val;
-                else
-                    last = val.Substring(val.Length - ShowLast);
+                var last = ShowLast > val.Length ? val : val.Substring(val.Length - ShowLast);
 
-                if (PreserveLength && IsDefaultMask())
-                {
-                    var mask = "";
-                    if (ShowLast <= val.Length)
-                        mask = new String(Text[0], val.Length - ShowLast);
+                if (!PreserveLength || !IsDefaultMask())
+                    return Text + last;
 
-                    return mask + last;
-                }
+                var mask = "";
+                if (ShowLast <= val.Length)
+                    mask = new string(Text[0], val.Length - ShowLast);
 
-                return Text + last;
+                return mask + last;
             }
 
             if (ShowFirst > 0 && ShowLast > 0)

--- a/src/Destructurama.Attributed/LoggerConfigurationAttributedExtensions.cs
+++ b/src/Destructurama.Attributed/LoggerConfigurationAttributedExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014 Serilog Contributors
+﻿// Copyright 2014-2018 Destructurama Contributors, Serilog Contributors
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -33,4 +33,3 @@ namespace Destructurama
         }
     }
 }
-

--- a/src/Destructurama.Attributed/Util/CacheEntry.cs
+++ b/src/Destructurama.Attributed/Util/CacheEntry.cs
@@ -18,18 +18,18 @@ using Serilog.Events;
 
 namespace Destructurama.Util
 {
-    internal struct CacheEntry
+    struct CacheEntry
     {
         public CacheEntry(Func<object, ILogEventPropertyValueFactory, LogEventPropertyValue> destructureFunc)
         {
             CanDestructure = true;
-            DestructureFunc = destructureFunc;
+            DestructureFunc = destructureFunc ?? throw new ArgumentNullException(nameof(destructureFunc));
         }
 
-        private CacheEntry(bool canDestructure, Func<object, ILogEventPropertyValueFactory, LogEventPropertyValue> destructureFunc)
+        CacheEntry(bool canDestructure, Func<object, ILogEventPropertyValueFactory, LogEventPropertyValue> destructureFunc)
         {
             CanDestructure = canDestructure;
-            DestructureFunc = destructureFunc;
+            DestructureFunc = destructureFunc ?? throw new ArgumentNullException(nameof(destructureFunc));
         }
 
         public bool CanDestructure { get; }

--- a/src/Destructurama.Attributed/Util/GetablePropertyFinder.cs
+++ b/src/Destructurama.Attributed/Util/GetablePropertyFinder.cs
@@ -19,9 +19,9 @@ using System.Reflection;
 
 namespace Destructurama.Util
 {
-    internal static class GetablePropertyFinder
+    static class GetablePropertyFinder
     {
-        internal static IEnumerable<PropertyInfo> GetPropertiesRecursive(this Type type)
+        public static IEnumerable<PropertyInfo> GetPropertiesRecursive(this Type type)
         {
             var seenNames = new HashSet<string>();
 

--- a/test/Destructurama.Attributed.Tests/MaskedAttributeTests.cs
+++ b/test/Destructurama.Attributed.Tests/MaskedAttributeTests.cs
@@ -2,7 +2,6 @@
 using NUnit.Framework;
 using Serilog;
 using Serilog.Events;
-using System;
 using System.Linq;
 
 namespace Destructurama.Attributed.Tests
@@ -18,85 +17,85 @@ namespace Destructurama.Attributed.Tests
         /// <summary>
         /// 123456789 results in "*********"
         /// </summary>
-        [LogMasked(PreserveLength: true)]
+        [LogMasked(PreserveLength = true)]
         public string DefaultMaskedPreserved { get; set; }
 
         /// <summary>
         ///  123456789 results in "#"
         /// </summary>
-        [LogMasked(Text: "_REMOVED_")]
+        [LogMasked(Text = "_REMOVED_")]
         public string CustomMasked { get; set; }
 
         /// <summary>
         ///  123456789 results in "#########"
         /// </summary>
-        [LogMasked(Text: "#", PreserveLength: true)]
+        [LogMasked(Text = "#", PreserveLength = true)]
         public string CustomMaskedPreservedLength { get; set; }
 
         /// <summary>
         ///  123456789 results in "123******"
         /// </summary>
-        [LogMasked(ShowFirst: 3)]
+        [LogMasked(ShowFirst = 3)]
         public string ShowFirstThreeThenDefaultMasked { get; set; }
 
         /// <summary>
         /// 123456789 results in "123******"
         /// </summary>
-        [LogMasked(ShowFirst: 3, PreserveLength: true)]
+        [LogMasked(ShowFirst = 3, PreserveLength = true)]
         public string ShowFirstThreeThenDefaultMaskedPreservedLength { get; set; }
 
         /// <summary>
         /// 123456789 results in "***789"
         /// </summary>
-        [LogMasked(ShowLast: 3)]
+        [LogMasked(ShowLast = 3)]
         public string ShowLastThreeThenDefaultMasked { get; set; }
 
         /// <summary>
         /// 123456789 results in "******789"
         /// </summary>
-        [LogMasked(ShowLast: 3, PreserveLength: true)]
+        [LogMasked(ShowLast = 3, PreserveLength = true)]
         public string ShowLastThreeThenDefaultMaskedPreservedLength { get; set; }
 
         /// <summary>
         ///  123456789 results in "123REMOVED"
         /// </summary>
-        [LogMasked(Text: "_REMOVED_", ShowFirst: 3)]
+        [LogMasked(Text = "_REMOVED_", ShowFirst = 3)]
         public string ShowFirstThreeThenCustomMask { get; set; }
 
         /// <summary>
         ///  123456789 results in "123_REMOVED_"
         /// </summary>
-        [LogMasked(Text: "_REMOVED_", ShowFirst: 3, PreserveLength: true)]
+        [LogMasked(Text = "_REMOVED_", ShowFirst = 3, PreserveLength = true)]
         public string ShowFirstThreeThenCustomMaskPreservedLengthIgnored { get; set; }
 
         /// <summary>
         ///  123456789 results in "_REMOVED_789"
         /// </summary>
-        [LogMasked(Text: "_REMOVED_", ShowLast: 3)]
+        [LogMasked(Text = "_REMOVED_", ShowLast = 3)]
         public string ShowLastThreeThenCustomMask { get; set; }
 
         /// <summary>
         ///  123456789 results in "_REMOVED_789"
         /// </summary>
-        [LogMasked(Text: "_REMOVED_", ShowLast: 3, PreserveLength: true)]
+        [LogMasked(Text = "_REMOVED_", ShowLast = 3, PreserveLength = true)]
         public string ShowLastThreeThenCustomMaskPreservedLengthIgnored { get; set; }
 
         /// <summary>
         /// 123456789 results in "123***789"
         /// </summary>
-        [LogMasked(ShowFirst: 3, ShowLast: 3)]
+        [LogMasked(ShowFirst = 3, ShowLast = 3)]
         public string ShowFirstAndLastThreeAndDefaultMaskeInTheMiddle { get; set; }
 
         /// <summary>
         ///  123456789 results in "123_REMOVED_789                                                                                                                                                                                                                                                                                                                <               °                       °    °                                         °                     789"
         /// </summary>
-        [LogMasked(Text: "_REMOVED_", ShowFirst: 3, ShowLast: 3)]
+        [LogMasked(Text = "_REMOVED_", ShowFirst = 3, ShowLast = 3)]
         public string ShowFirstAndLastThreeAndCustomMaskInTheMiddle { get; set; }
 
         /// <summary>
         ///  123456789 results in "123_REMOVED_789". PreserveLength is ignored                                                                                                                                                                                                                                                                                                          <               °                       °    °                                         °                     789"
         /// </summary>
-        [LogMasked(Text: "_REMOVED_", ShowFirst: 3, ShowLast: 3, PreserveLength: true)]
+        [LogMasked(Text = "_REMOVED_", ShowFirst = 3, ShowLast = 3, PreserveLength = true)]
         public string ShowFirstAndLastThreeAndCustomMaskInTheMiddlePreservedLengthIgnored { get; set; }
     }
 
@@ -160,7 +159,7 @@ namespace Destructurama.Attributed.Tests
         [Test]
         public void LogMaskedAttribute_Replaces_Value_With_Provided_Mask()
         {
-            //  [LogMasked(Text: "#")]
+            //  [LogMasked(Text = "#")]
             //   123456789 -> "_REMOVED_"
 
             LogEvent evt = null;
@@ -187,7 +186,7 @@ namespace Destructurama.Attributed.Tests
         [Test]
         public void LogMaskedAttribute_Replaces_Value_With_Provided_Mask_And_PreservedLength()
         {
-            //  [LogMasked(Text: "#")]
+            //  [LogMasked(Text = "#")]
             //   123456789 -> "#########"
 
             LogEvent evt = null;
@@ -214,7 +213,7 @@ namespace Destructurama.Attributed.Tests
         [Test]
         public void LogMaskedAttribute_Shows_First_NChars_Then_Replaces_All_With_Custom_Mask()
         {
-            // [LogMasked(Text: "REMOVED", ShowFirst = 3)]
+            // [LogMasked(Text = "REMOVED", ShowFirst = 3)]
             // -> "123_REMOVED_"
 
             LogEvent evt = null;
@@ -241,7 +240,7 @@ namespace Destructurama.Attributed.Tests
         [Test]
         public void LogMaskedAttribute_Shows_First_NChars_Then_Replaces_All_With_Custom_Mask_PreservedLength_Ignored()
         {
-            // [LogMasked(Text: "REMOVED", ShowFirst = 3,PreserveLength = true)]
+            // [LogMasked(Text = "REMOVED", ShowFirst = 3,PreserveLength = true)]
             // -> "123_REMOVED_"
 
             LogEvent evt = null;
@@ -295,7 +294,7 @@ namespace Destructurama.Attributed.Tests
         [Test]
         public void LogMaskedAttribute_Shows_First_NChars_And_Last_NChars_Then_Replaces_All_Other_Chars_With_Custom_Mask()
         {
-            // [LogMasked(Text: "REMOVED", ShowFirst = 3, ShowLast = 3)]
+            // [LogMasked(Text = "REMOVED", ShowFirst = 3, ShowLast = 3)]
             // 12345678987654321 -> 123_REMOVED_321     
 
             LogEvent evt = null;
@@ -322,7 +321,7 @@ namespace Destructurama.Attributed.Tests
         [Test]
         public void LogMaskedAttribute_Shows_First_NChars_And_Last_NChars_Then_Replaces_All_Other_Chars_With_Custom_Mask_And_PreservedLength()
         {
-            // [LogMasked(Text: "#", ShowFirst = 3, ShowLast = 3)]
+            // [LogMasked(Text = "#", ShowFirst = 3, ShowLast = 3)]
             // 12345678987654321 -> "123_REMOVED_321"
 
             LogEvent evt = null;
@@ -349,7 +348,7 @@ namespace Destructurama.Attributed.Tests
         [Test]
         public void LogMaskedAttribute_Shows_First_NChars_And_Last_NChars_Then_Replaces_All_Other_Chars_With_Custom_Mask_And_PreservedLength_Even_When_Input_Length_Is_Less_Than_ShowFirst()
         {
-            // [LogMasked(Text: "#", ShowFirst = 3, ShowLast = 3)]
+            // [LogMasked(Text = "#", ShowFirst = 3, ShowLast = 3)]
             // 12 -> "12"
 
             LogEvent evt = null;
@@ -376,7 +375,7 @@ namespace Destructurama.Attributed.Tests
         [Test]
         public void LogMaskedAttribute_Shows_First_NChars_And_Last_NChars_Then_Replaces_All_Other_Chars_With_Custom_Mask_And_PreservedLength_Even_When_Input_Length_Is_Less_Than_ShowFirst_Plus_ShowLast()
         {
-            // [LogMasked(Text: "#", ShowFirst = 3, ShowLast = 3)]
+            // [LogMasked(Text = "#", ShowFirst = 3, ShowLast = 3)]
             // 1234 -> "1234"
 
             LogEvent evt = null;
@@ -430,7 +429,7 @@ namespace Destructurama.Attributed.Tests
         [Test]
         public void LogMaskedAttribute_Shows_Last_NChars_Then_Replaces_All_Other_Chars_With_Custom_Mask()
         {
-            //  [LogMasked(Text: "_REMOVED_", ShowLast = 3)]
+            //  [LogMasked(Text = "_REMOVED_", ShowLast = 3)]
             //  123456789 -> "_REMOVED_789"
 
             LogEvent evt = null;
@@ -457,7 +456,7 @@ namespace Destructurama.Attributed.Tests
         [Test]
         public void LogMaskedAttribute_Shows_Last_NChars_Then_Replaces_All_Other_Chars_With_Custom_Mask_PreserveLength_Ignored()
         {
-            //  [LogMasked(Text: "_REMOVED_", ShowLast = 3, PreserveLength = true)]
+            //  [LogMasked(Text = "_REMOVED_", ShowLast = 3, PreserveLength = true)]
             //  123456789 -> "_REMOVED_789"
 
             LogEvent evt = null;
@@ -511,7 +510,7 @@ namespace Destructurama.Attributed.Tests
         [Test]
         public void LogMaskedAttribute_Shows_First_NChars_Then_Replaces_All_Other_Chars_With_Default_StarMask_And_PreservedLength()
         {
-            //  [LogMasked(ShowFirst = 3,PreserveLength: true))]
+            //  [LogMasked(ShowFirst = 3,PreserveLength = true))]
             // -> "123******"
 
             LogEvent evt = null;
@@ -538,7 +537,7 @@ namespace Destructurama.Attributed.Tests
         [Test]
         public void LogMaskedAttribute_Shows_First_NChars_Then_Replaces_All_Other_Chars_With_Default_StarMask_And_PreservedLength_Even_For_An_Empty_Input()
         {
-            //  [LogMasked(ShowFirst = 3,PreserveLength: true))]
+            //  [LogMasked(ShowFirst = 3,PreserveLength = true))]
             // -> ""
 
             LogEvent evt = null;
@@ -566,7 +565,7 @@ namespace Destructurama.Attributed.Tests
         [Test]
         public void LogMaskedAttribute_Shows_First_NChars_Then_Replaces_All_Other_Chars_With_Default_StarMask_And_PreservedLength_Even_For_An_Input_With_Same_Length_As_ShowFirst()
         {
-            //  [LogMasked(ShowFirst = 3,PreserveLength: true))]
+            //  [LogMasked(ShowFirst = 3,PreserveLength = true))]
             // -> "123"
 
             LogEvent evt = null;
@@ -594,7 +593,7 @@ namespace Destructurama.Attributed.Tests
         [Test]
         public void LogMaskedAttribute_Shows_First_NChars_Then_Replaces_All_Other_Chars_With_Default_StarMask_And_PreservedLength_Even_For_An_Input_Shorter_Than_ShowFirst()
         {
-            //  [LogMasked(ShowFirst = 3,PreserveLength: true))]
+            //  [LogMasked(ShowFirst = 3,PreserveLength = true))]
             // -> "12"
 
             LogEvent evt = null;
@@ -622,7 +621,7 @@ namespace Destructurama.Attributed.Tests
         [Test]
         public void LogMaskedAttribute_Shows_Last_NChars_Then_Replaces_All_Other_Chars_With_Default_StarMask_And_PreservedLength()
         {
-            //  [LogMasked(ShowLast = 3,PreserveLength: true))]
+            //  [LogMasked(ShowLast = 3,PreserveLength = true))]
             // -> "******789"
 
             LogEvent evt = null;
@@ -649,7 +648,7 @@ namespace Destructurama.Attributed.Tests
         [Test]
         public void LogMaskedAttribute_Shows_Last_NChars_Then_Replaces_All_Other_Chars_With_Default_StarMask_And_PreservedLength_Even_For_An_Input_With_Same_Length_As_ShowLast()
         {
-            //  [LogMasked(ShowLast = 3,PreserveLength: true))]
+            //  [LogMasked(ShowLast = 3,PreserveLength = true))]
             // -> "123"
 
             LogEvent evt = null;
@@ -676,7 +675,7 @@ namespace Destructurama.Attributed.Tests
         [Test]
         public void LogMaskedAttribute_Shows_Last_NChars_Then_Replaces_All_Other_Chars_With_Default_StarMask_And_PreservedLength_Even_For_An_Input_Shorter_Than_ShowLast()
         {
-            //  [LogMasked(ShowLast = 3,PreserveLength: true))]
+            //  [LogMasked(ShowLast = 3,PreserveLength = true))]
             // -> "12"
 
             LogEvent evt = null;
@@ -703,7 +702,7 @@ namespace Destructurama.Attributed.Tests
         [Test]
         public void LogMaskedAttribute_Shows_First_NChars_And_Last_NChars_Then_Replaces_All_Other_Chars_With_Custom_Mask_And_PreservedLength_That_Gives_Warning()
         {
-            // [LogMasked(Text: "REMOVED", ShowFirst = 3, ShowLast = 3, PreserveLength = true)]
+            // [LogMasked(Text = "REMOVED", ShowFirst = 3, ShowLast = 3, PreserveLength = true)]
             // 12345678987654321 -> 123_REMOVED_321 
 
             LogEvent evt = null;


### PR DESCRIPTION
 - avoid invoking cached destructuring policies under the cache lock
 - use standard attribute property initialization for `LogMaskedAttribute` (breaking change; we're shipping a new major version)
 - use consistent default modifiers
 - update copyright notices
