### PR TITLE
readme: Fix 'LogMasked' example

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Apply the `LogMasked` attribute with various settings:
 public class Creditcard
 {
   /// <summary>
-  /// 123456789 results in "*********"
+  /// 123456789 results in "***"
   /// </summary>
   [LogMasked]
   public string DefaultMasked { get; set; }


### PR DESCRIPTION
LogMasked example incorrectly shows

    "123456789" masked to "*********"

which is incorrect. It should be

    "***"

So fix it.