### PR TITLE
Fix issue #34 - LogMasked with ShowsFirst, ShowsLast, PreserveLength

### DIFF
--- a/src/Destructurama.Attributed/Attributed/LogMaskedAttribute.cs
+++ b/src/Destructurama.Attributed/Attributed/LogMaskedAttribute.cs
@@ -90,7 +90,11 @@ namespace Destructurama.Attributed
                 var first = val.Substring(0, ShowFirst);
                 var last = val.Substring(val.Length - ShowLast);
 
-                return first + Text + last;
+                string mask = null;
+                if(PreserveLength && IsDefaultMask())
+                    mask = new string(Text[0], val.Length - ShowFirst - ShowLast);
+
+                return first + (mask ?? Text) + last;
             }
 
             return propValue;

--- a/src/Destructurama.Attributed/Attributed/LogMaskedAttribute.cs
+++ b/src/Destructurama.Attributed/Attributed/LogMaskedAttribute.cs
@@ -91,7 +91,7 @@ namespace Destructurama.Attributed
                 var last = val.Substring(val.Length - ShowLast);
 
                 string mask = null;
-                if(PreserveLength && IsDefaultMask())
+                if (PreserveLength && IsDefaultMask())
                     mask = new string(Text[0], val.Length - ShowFirst - ShowLast);
 
                 return first + (mask ?? Text) + last;

--- a/test/Destructurama.Attributed.Tests/MaskedAttributeTests.cs
+++ b/test/Destructurama.Attributed.Tests/MaskedAttributeTests.cs
@@ -274,7 +274,7 @@ namespace Destructurama.Attributed.Tests
         public void LogMaskedAttribute_Shows_First_NChars_And_Last_NChars_Replaces_Value_With_Default_StarMask()
         {
             // [LogMasked(ShowFirst = 3, ShowLast = 3)]
-            // -> "123***********321"
+            // -> "123***321"
 
             LogEvent evt = null;
 

--- a/test/Destructurama.Attributed.Tests/MaskedAttributeTests.cs
+++ b/test/Destructurama.Attributed.Tests/MaskedAttributeTests.cs
@@ -84,7 +84,13 @@ namespace Destructurama.Attributed.Tests
         /// 123456789 results in "123***789"
         /// </summary>
         [LogMasked(ShowFirst = 3, ShowLast = 3)]
-        public string ShowFirstAndLastThreeAndDefaultMaskeInTheMiddle { get; set; }
+        public string ShowFirstAndLastThreeAndDefaultMaskInTheMiddle { get; set; }
+
+        /// <summary>
+        /// 123456789 results in "123***789"
+        /// </summary>
+        [LogMasked(ShowFirst = 3, ShowLast = 3, PreserveLength = true)]
+        public string ShowFirstAndLastThreeAndDefaultMaskInTheMiddlePreservedLength { get; set; }
 
         /// <summary>
         ///  123456789 results in "123_REMOVED_789                                                                                                                                                                                                                                                                                                                <               °                       °    °                                         °                     789"
@@ -268,7 +274,7 @@ namespace Destructurama.Attributed.Tests
         public void LogMaskedAttribute_Shows_First_NChars_And_Last_NChars_Replaces_Value_With_Default_StarMask()
         {
             // [LogMasked(ShowFirst = 3, ShowLast = 3)]
-            // -> "1234*********4321"
+            // -> "123***********321"
 
             LogEvent evt = null;
 
@@ -279,7 +285,7 @@ namespace Destructurama.Attributed.Tests
 
             var customized = new CustomizedMaskedLogs
             {
-                ShowFirstAndLastThreeAndDefaultMaskeInTheMiddle = "12345678987654321"
+                ShowFirstAndLastThreeAndDefaultMaskInTheMiddle = "12345678987654321"
             };
 
             log.Information("Here is {@Customized}", customized);
@@ -287,8 +293,62 @@ namespace Destructurama.Attributed.Tests
             var sv = (StructureValue)evt.Properties["Customized"];
             var props = sv.Properties.ToDictionary(p => p.Name, p => p.Value);
 
-            Assert.IsTrue(props.ContainsKey("ShowFirstAndLastThreeAndDefaultMaskeInTheMiddle"));
-            Assert.AreEqual("123***321", props["ShowFirstAndLastThreeAndDefaultMaskeInTheMiddle"].LiteralValue());
+            Assert.IsTrue(props.ContainsKey("ShowFirstAndLastThreeAndDefaultMaskInTheMiddle"));
+            Assert.AreEqual("123***321", props["ShowFirstAndLastThreeAndDefaultMaskInTheMiddle"].LiteralValue());
+        }
+
+        [Test]
+        public void LogMaskedAttribute_Shows_First_NChars_And_Last_NChars_Replaces_Value_With_Default_StarMask_PreserveLength()
+        {
+            // [LogMasked(ShowFirst = 3, ShowLast = 3)]
+            // -> "123***********321"
+
+            LogEvent evt = null;
+
+            var log = new LoggerConfiguration()
+                .Destructure.UsingAttributes()
+                .WriteTo.Sink(new DelegatingSink(e => evt = e))
+                .CreateLogger();
+
+            var customized = new CustomizedMaskedLogs
+            {
+                ShowFirstAndLastThreeAndDefaultMaskInTheMiddlePreservedLength = "12345678987654321"
+            };
+
+            log.Information("Here is {@Customized}", customized);
+
+            var sv = (StructureValue)evt.Properties["Customized"];
+            var props = sv.Properties.ToDictionary(p => p.Name, p => p.Value);
+
+            Assert.IsTrue(props.ContainsKey("ShowFirstAndLastThreeAndDefaultMaskInTheMiddlePreservedLength"));
+            Assert.AreEqual("123***********321", props["ShowFirstAndLastThreeAndDefaultMaskInTheMiddlePreservedLength"].LiteralValue());
+        }
+
+        [Test]
+        public void LogMaskedAttribute_Shows_First_NChars_And_Last_NChars_Replaces_Value_With_Default_StarMask_Single_PreserveLength()
+        {
+            // [LogMasked(ShowFirst = 3, ShowLast = 3)]
+            // -> "123*456"
+
+            LogEvent evt = null;
+
+            var log = new LoggerConfiguration()
+                .Destructure.UsingAttributes()
+                .WriteTo.Sink(new DelegatingSink(e => evt = e))
+                .CreateLogger();
+
+            var customized = new CustomizedMaskedLogs
+            {
+                ShowFirstAndLastThreeAndDefaultMaskInTheMiddlePreservedLength = "123x456"
+            };
+
+            log.Information("Here is {@Customized}", customized);
+
+            var sv = (StructureValue)evt.Properties["Customized"];
+            var props = sv.Properties.ToDictionary(p => p.Name, p => p.Value);
+
+            Assert.IsTrue(props.ContainsKey("ShowFirstAndLastThreeAndDefaultMaskInTheMiddlePreservedLength"));
+            Assert.AreEqual("123*456", props["ShowFirstAndLastThreeAndDefaultMaskInTheMiddlePreservedLength"].LiteralValue());
         }
 
         [Test]


### PR DESCRIPTION
Fixes Issue #34 for `LogMasked` attribute where `PreserveLength` is ignored if both `ShowsFirst` and `ShowsLast` Properties are defined

Summary of changes:
- [x] Change LogMasked functionality when define ShowsFirst, ShowsLast and PreserveLength
- [x] Write Unit Tests