### PR TITLE
Support MetadataType  Attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,54 @@ public class WithRegex
 <sup><a href='/src/Destructurama.Attributed.Tests/Snippets.cs#L6-L25' title='Snippet source file'>snippet source</a> | <a href='#snippet-WithRegex' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
+## 8. Working with Metadataclass Attribute
+
+Apply the attribute `NotLogged` to the property in your MetadataClass
+
+### Examples
+
+```cs
+    /// <summary>
+    /// Simple Metadata Sample
+    /// </summary>
+    [MetadataType(typeof(DtoMetadata))]
+    public partial class Dto
+    {
+        public string Private { get; set; }
+
+        public string Public { get; set; }
+    }
+
+    internal class DtoMetadata
+    {
+        [NotLogged]
+        public object Private { get; set; }
+    }
+
+    /// <summary>
+    /// Metadata Sample with derived subclass
+    /// </summary>
+    [MetadataType(typeof(DtoMetadataDerived))]
+    public partial class DtoWithDerived
+    {
+        public string Private { get; set; }
+
+        public string Public { get; set; }
+    }
+
+    internal class DtoMetadataBase
+    {
+        public object Public { get; set; }
+    }
+
+    internal class DtoMetadataDerived : DtoMetadataBase
+    {
+        [NotLogged]
+        public object Private { get; set; }
+    }
+
+```
+
 # Benchmarks
 
 The results are available [here](https://destructurama.github.io/attributed/dev/bench/).

--- a/README.md
+++ b/README.md
@@ -374,7 +374,15 @@ public class WithRegex
 
 ## 8. Working with Metadataclass Attribute
 
-Apply the attribute `NotLogged` to the property in your MetadataClass
+Apply the attribute `NotLogged` to the property in your MetadataClass. 
+
+This requires to set configuration option UseMetadataTypeAttribute to true.
+
+```csharp
+var log = new LoggerConfiguration()
+  .Destructure.UsingAttributes(x => x.UseMetadataTypeAttribute = true)
+  ...
+```
 
 ### Examples
 

--- a/README.md
+++ b/README.md
@@ -374,9 +374,7 @@ public class WithRegex
 
 ## 8. Working with MetadataTypeAttribute
 
-Apply the attribute `NotLogged` to the property in your MetadataClass. 
-
-This requires to set configuration option UseMetadataTypeAttribute to true.
+You can apply [`MetadataTypeAttribute`](https://learn.microsoft.com/en-us/dotnet/api/system.componentmodel.dataannotations.metadatatypeattribute) to your class providing another type with annotated properties. It may help you in the case when source type with its properties is defined in a code generated file so you don't want to put the attributes in there as they would get overwritten by the generator. Note that you have to set `AttributedDestructuringPolicyOptions.RespectMetadataTypeAttribute` to `true`.
 
 ```csharp
 var log = new LoggerConfiguration()

--- a/src/Destructurama.Attributed.Tests/MetadataTypeTests.cs
+++ b/src/Destructurama.Attributed.Tests/MetadataTypeTests.cs
@@ -9,6 +9,7 @@ namespace Destructurama.Attributed.Tests;
 [TestFixture]
 public class MetadataTypeTests
 {
+#if NET5_0_OR_GREATER
     [Test]
     public void MetadataType_Should_Be_Respected()
     {
@@ -26,7 +27,27 @@ public class MetadataTypeTests
         props.Count.ShouldBe(1);
         props["Public"].LiteralValue().ShouldBe("not_Secret");
     }
+    [Test]
+    public void MetadataTypeWithDerived_Should_Be_Respected()
+    {
+        var customized = new DtoWithDerived
+        {
+            Private = "secret",
+            Public = "not_Secret"
+        };
 
+        var evt = DelegatingSink.Execute(customized);
+
+        var sv = (StructureValue)evt.Properties["Customized"];
+        var props = sv.Properties.ToDictionary(p => p.Name, p => p.Value);
+
+        props.Count.ShouldBe(1);
+        props["Public"].LiteralValue().ShouldBe("not_Secret");
+    }
+#endif
+    /// <summary>
+    /// Simple Metadata Sample
+    /// </summary>
     [MetadataType(typeof(DtoMetadata))]
     public partial class Dto
     {
@@ -40,4 +61,28 @@ public class MetadataTypeTests
         [NotLogged]
         public object Private { get; set; }
     }
+
+    /// <summary>
+    /// Metadata Sample with derived subclass
+    /// </summary>
+    [MetadataType(typeof(DtoMetadataDerived))]
+    public partial class DtoWithDerived
+    {
+        public string Private { get; set; }
+
+        public string Public { get; set; }
+    }
+
+    internal class DtoMetadataBase
+    {
+        public object Public { get; set; }
+    }
+
+    internal class DtoMetadataDerived : DtoMetadataBase
+    {
+        [NotLogged]
+        public object Private { get; set; }
+    }
+
+
 }

--- a/src/Destructurama.Attributed.Tests/MetadataTypeTests.cs
+++ b/src/Destructurama.Attributed.Tests/MetadataTypeTests.cs
@@ -10,6 +10,36 @@ namespace Destructurama.Attributed.Tests;
 public class MetadataTypeTests
 {
 #if NET5_0_OR_GREATER
+    [SetUp]
+    public void SetUp()
+    {
+        AttributedDestructuringPolicy.Clear();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        AttributedDestructuringPolicy.Clear();
+    }
+
+    [Test]
+    public void MetadataType_Should_Not_Be_Respected()
+    {
+        var customized = new Dto
+        {
+            Private = "secret",
+            Public = "not_Secret"
+        };
+
+        var evt = DelegatingSink.Execute(customized);
+
+        var sv = (StructureValue)evt.Properties["Customized"];
+        var props = sv.Properties.ToDictionary(p => p.Name, p => p.Value);
+
+        props.Count.ShouldBe(2);
+        props["Public"].LiteralValue().ShouldBe("not_Secret");
+        props["Private"].LiteralValue().ShouldBe("secret");
+    }
     [Test]
     public void MetadataType_Should_Be_Respected()
     {
@@ -19,7 +49,7 @@ public class MetadataTypeTests
             Public = "not_Secret"
         };
 
-        var evt = DelegatingSink.Execute(customized);
+        var evt = DelegatingSink.Execute(customized, configure: opt => opt.UseMetadataTypeAttribute = true);
 
         var sv = (StructureValue)evt.Properties["Customized"];
         var props = sv.Properties.ToDictionary(p => p.Name, p => p.Value);
@@ -36,7 +66,7 @@ public class MetadataTypeTests
             Public = "not_Secret"
         };
 
-        var evt = DelegatingSink.Execute(customized);
+        var evt = DelegatingSink.Execute(customized, configure: opt => opt.UseMetadataTypeAttribute = true);
 
         var sv = (StructureValue)evt.Properties["Customized"];
         var props = sv.Properties.ToDictionary(p => p.Name, p => p.Value);

--- a/src/Destructurama.Attributed/Attributed/AttributedDestructuringPolicy.cs
+++ b/src/Destructurama.Attributed/Attributed/AttributedDestructuringPolicy.cs
@@ -77,11 +77,6 @@ internal class AttributedDestructuringPolicy : IDestructuringPolicy
 #endif
             foreach (var propertyInfo in unseenProperties)
             {
-#if NETSTANDARD2_1_OR_GREATER
-                if (metaProp.Any(p => p.Name == propertyInfo.Name))
-                {
-                }
-#endif
                 seenNames.Add(propertyInfo.Name);
                 yield return propertyInfo;
             }

--- a/src/Destructurama.Attributed/Attributed/AttributedDestructuringPolicy.cs
+++ b/src/Destructurama.Attributed/Attributed/AttributedDestructuringPolicy.cs
@@ -61,15 +61,15 @@ internal class AttributedDestructuringPolicy : IDestructuringPolicy
 
 #if NETSTANDARD2_1_OR_GREATER
             var metaProp = new List<PropertyInfo>();
-            /// find Metadata Class
-            /// Take only first Entry, unclear from docs whether it can be specified multiple times, would be nonsense from my perspective
+            // find Metadata Class
+            // Take only first Entry, unclear from docs whether it can be specified multiple times, would be nonsense from my perspective
             var metaDataType = type.GetCustomAttributes<MetadataTypeAttribute>(true).ToList().FirstOrDefault();
             if (metaDataType != null)
             {
                 var metaClass = metaDataType.MetadataClassType;
-                /// find all properties with Custom Attributes which are in referenced class
+                // find all properties with Custom Attributes which are in referenced class
                 metaProp = metaClass.GetProperties().Where(mp =>mp.CustomAttributes.Count() > 0 && unseenProperties.Any(up => up.Name == mp.Name)).ToList();
-                /// replace all found properties in unseenProperties with those from Metadataclass
+                // replace all found properties in unseenProperties with those from Metadataclass
                 var removedAttr = unseenProperties.Where(up => metaProp.Any(mp => mp.Name != up.Name)).ToList();
                 removedAttr.AddRange(metaProp);
                 unseenProperties = removedAttr;

--- a/src/Destructurama.Attributed/Attributed/AttributedDestructuringPolicyOptions.cs
+++ b/src/Destructurama.Attributed/Attributed/AttributedDestructuringPolicyOptions.cs
@@ -19,4 +19,8 @@ public class AttributedDestructuringPolicyOptions
     /// This works the same as when applying <see cref="NotLoggedAttribute"/> to the property but may help if you have no access to it's source code.
     /// </summary>
     public bool RespectLogPropertyIgnoreAttribute { get; set; }
+    /// <summary>
+    /// By setting this property to <see langword="true"/> the attributes declared in Metadatatype class will be used associated with data class
+    /// </summary>
+    public bool UseMetadataTypeAttribute { get; set; }
 }

--- a/src/Destructurama.Attributed/Attributed/AttributedDestructuringPolicyOptions.cs
+++ b/src/Destructurama.Attributed/Attributed/AttributedDestructuringPolicyOptions.cs
@@ -19,6 +19,7 @@ public class AttributedDestructuringPolicyOptions
     /// This works the same as when applying <see cref="NotLoggedAttribute"/> to the property but may help if you have no access to it's source code.
     /// </summary>
     public bool RespectLogPropertyIgnoreAttribute { get; set; }
+
     /// <summary>
     /// Respect MetadataTypeAttribute pointing to another class with annotated properties.
     /// </summary>

--- a/src/Destructurama.Attributed/Attributed/AttributedDestructuringPolicyOptions.cs
+++ b/src/Destructurama.Attributed/Attributed/AttributedDestructuringPolicyOptions.cs
@@ -22,5 +22,5 @@ public class AttributedDestructuringPolicyOptions
     /// <summary>
     /// By setting this property to <see langword="true"/> the attributes declared in Metadatatype class will be used associated with data class
     /// </summary>
-    public bool UseMetadataTypeAttribute { get; set; }
+    public bool RespectMetadataTypeAttribute { get; set; }
 }

--- a/src/Destructurama.Attributed/Attributed/AttributedDestructuringPolicyOptions.cs
+++ b/src/Destructurama.Attributed/Attributed/AttributedDestructuringPolicyOptions.cs
@@ -20,7 +20,7 @@ public class AttributedDestructuringPolicyOptions
     /// </summary>
     public bool RespectLogPropertyIgnoreAttribute { get; set; }
     /// <summary>
-    /// By setting this property to <see langword="true"/> the attributes declared in Metadatatype class will be used associated with data class
+    /// Respect MetadataTypeAttribute pointing to another class with annotated properties.
     /// </summary>
     public bool RespectMetadataTypeAttribute { get; set; }
 }


### PR DESCRIPTION
Adds support from MetadataType Attribute, see https://github.com/destructurama/attributed/issues/40 

According to https://learn.microsoft.com/en-us/dotnet/api/system.componentmodel.dataannotations.metadatatypeattribute?view=net-9.0#remarks 

- The MetadataType attribute can only applied to a class
- The attribute cannot be inherited by derived classes.
- can only applied once
- Netstandard 2.0 or below is not supported 

Changed code replaces the PropertyInfo from base class with PropertyInfo property of MetadataType for equal named properties. 

